### PR TITLE
Corrects repo links

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,16 +8,16 @@ This plugin is licensed with the Apache 2.0 license.
 
 ### [Antigen](https://github.com/zsh-users/antigen)
 
-Add `antigen bundle unixorn/rvm-plugin.plugin.zsh` to your `.zshrc` with your other bundle commands.
+Add `antigen bundle unixorn/rvm-plugin` to your `.zshrc` with your other bundle commands.
 
-Antigen will handle cloning the plugin for you automatically the next time you start zsh. You can also add the plugin to a running zsh with `antigen bundle unixorn/rvm-plugin.plugin.zsh` for testing before adding it to your `.zshrc`.
+Antigen will handle cloning the plugin for you automatically the next time you start zsh. You can also add the plugin to a running zsh with `antigen bundle unixorn/rvm-plugin` for testing before adding it to your `.zshrc`.
 
 ### [Oh-My-Zsh](http://ohmyz.sh/)
 
 1. `cd ~/.oh-my-zsh/custom/plugins`
-2. `git clone git@github.com:unixorn/rvm-plugin.plugin.zsh.git rvmplugin`
+2. `git clone git@github.com:unixorn/rvm-plugin.git rvmplugin`
 3. Add tumult to your plugin list - edit `~.zshrc` and change `plugins=(...)` to `plugins=(... rvmplugin)`
 
 ### [Zgen](https://github.com/tarjoilija/zgen)
 
-Add `zgen load unixorn/rvm-plugin.plugin.zsh` to your .zshrc file in the same function you're doing your other `zgen load` calls in.
+Add `zgen load unixorn/rvm-plugin` to your .zshrc file in the same function you're doing your other `zgen load` calls in.


### PR DESCRIPTION
`https://github.com/unixorn/rvm-plugin.plugin.zsh.git` is not a valid Github URL, so I corrected it.
